### PR TITLE
refactor: harden crypto modules and add regression tests

### DIFF
--- a/algorithms/RSAalgorithm.py
+++ b/algorithms/RSAalgorithm.py
@@ -1,110 +1,78 @@
-from Crypto import Random
-from Crypto.Hash import SHA
-from Crypto.Cipher import PKCS1_v1_5 as Cipher_pkcs1_v1_5
-from Crypto.Signature import PKCS1_v1_5 as Signature_pkcs1_v1_5
-from Crypto.PublicKey import RSA
+"""RSA encryption/signature helpers."""
+
+from __future__ import annotations
+
 import base64
-random_generator= Random.new().read
-print("rand:",random_generator)
-def RsaEncrypt(message,key):
-    rsakey = RSA.importKey(key) #生成RSA密钥对象
-    cipher = Cipher_pkcs1_v1_5.new(rsakey)   #生成一个pkcs1 对象
-    if isinstance(message,str):
-        message=message.encode('utf-8')
-    cipher_text = base64.b64encode(cipher.encrypt(message)) #生成一个bytes对象
-    print(cipher_text.decode('utf-8'))
-    return cipher_text  #返回一个bytes对象，如果要显示需要utf8编码
-def RsaDecrypt(encrypt_text,key):
-    global random_generator
-    rsakey = RSA.importKey(key)
-    cipher = Cipher_pkcs1_v1_5.new(rsakey)
-    if isinstance(encrypt_text,str):
-        encrypt_text=base64.b64decode(encrypt_text)
-    text = cipher.decrypt(encrypt_text,random_generator)
-    print("测试点test",type(text))
-    return text    #返回bytes对象，显示需要utf8编码
+from typing import Union
 
-def RsaSignal(message,key):
-    if isinstance(message,str):
-        message=message.encode()
-    rsakey = RSA.importKey(key)
-    signer = Signature_pkcs1_v1_5.new(rsakey)
+from Crypto.Cipher import PKCS1_v1_5 as CipherPKCS1v15
+from Crypto.Hash import SHA
+from Crypto.PublicKey import RSA
+from Crypto.Signature import PKCS1_v1_5 as SignaturePKCS1v15
+
+BytesLike = Union[bytes, bytearray]
+
+
+def _to_bytes(value: Union[str, BytesLike]) -> bytes:
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value)
+    if isinstance(value, str):
+        return value.encode("utf-8")
+    raise TypeError(f"Unsupported value type: {type(value)!r}")
+
+
+def _import_key(key: Union[str, BytesLike]):
+    return RSA.import_key(_to_bytes(key))
+
+
+def RsaEncrypt(message: Union[str, BytesLike], key: Union[str, BytesLike]) -> bytes:
+    """Encrypt plaintext using RSA public key, returning base64 bytes."""
+    rsa_key = _import_key(key)
+    cipher = CipherPKCS1v15.new(rsa_key)
+    cipher_text = cipher.encrypt(_to_bytes(message))
+    return base64.b64encode(cipher_text)
+
+
+def RsaDecrypt(encrypt_text: Union[str, BytesLike], key: Union[str, BytesLike]) -> bytes:
+    """Decrypt RSA ciphertext (base64 text/bytes), returning plaintext bytes."""
+    rsa_key = _import_key(key)
+    cipher = CipherPKCS1v15.new(rsa_key)
+
+    encrypted_bytes = _to_bytes(encrypt_text)
+    try:
+        encrypted_bytes = base64.b64decode(encrypted_bytes)
+    except Exception as exc:  # noqa: BLE001 - preserve behavior with clearer error
+        raise ValueError("Invalid RSA ciphertext: expected base64 input") from exc
+
+    sentinel = b""
+    plain = cipher.decrypt(encrypted_bytes, sentinel)
+    if plain == sentinel:
+        raise ValueError("RSA decryption failed")
+    return plain
+
+
+def RsaSignal(message: Union[str, BytesLike], key: Union[str, BytesLike]) -> bytes:
+    """Sign message and return base64 signature bytes."""
+    rsa_key = _import_key(key)
+    signer = SignaturePKCS1v15.new(rsa_key)
+
     digest = SHA.new()
-    digest.update(message)
-    sign = signer.sign(digest)
-    signature = base64.b64encode(sign)
-    print(signature)
-    return signature
+    digest.update(_to_bytes(message))
+    signature = signer.sign(digest)
+    return base64.b64encode(signature)
 
-def VerRsaSignal(message,signature,key):
-    if isinstance(message,str):
-        message=message.encode()
-    print("signtype",type(signature))
-    rsakey = RSA.importKey(key)
-    verifier = Signature_pkcs1_v1_5.new(rsakey)
+
+def VerRsaSignal(
+    message: Union[str, BytesLike],
+    signature: Union[str, BytesLike],
+    key: Union[str, BytesLike],
+) -> bool:
+    """Verify base64 signature for message with RSA public key."""
+    rsa_key = _import_key(key)
+    verifier = SignaturePKCS1v15.new(rsa_key)
 
     digest = SHA.new()
-    # Assumes the data is base64 encoded to begin with
-    digest.update(message)
+    digest.update(_to_bytes(message))
 
-    is_verify = verifier.verify(digest, base64.b64decode(signature))
-    print(is_verify)
-    return is_verify
-
-if __name__ == '__main__':
-    mes='你好yo'
-    pubkey='''-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvSChFb9Y6xwb+XTMIcHR
-Q5lujD1J7v93TwJvUE7e6SEVpQEjfFKpjVEFpJUONdagBRYYkO4TA6k9gpAPmPCF
-nucttQBMAkTMDtxLndOKI0MOc5THw0h1fschm6CyJzkGoVYlPr0vU2Oq10yK0s7y
-uYqTzJB5sOLjRCGxdIw9V3UmpggK+IfQ6yXrM/dXy4h13zR6IzHnJ8tBH0VvvPes
-z/fMrN/HWw6av13CZuS12qEU/Jij+8ZvpKxn6kd1BO4+g9UW4ExsEq95+qFTOJIj
-hlm7yJCCsHfNq/r1nIa/NbpigQG0TS26r8sWTLgPmYysBTONFwX+NtCbbESRwRMo
-gQIDAQAB
------END PUBLIC KEY-----'''
-    prikey='''-----BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEAvSChFb9Y6xwb+XTMIcHRQ5lujD1J7v93TwJvUE7e6SEVpQEj
-fFKpjVEFpJUONdagBRYYkO4TA6k9gpAPmPCFnucttQBMAkTMDtxLndOKI0MOc5TH
-w0h1fschm6CyJzkGoVYlPr0vU2Oq10yK0s7yuYqTzJB5sOLjRCGxdIw9V3UmpggK
-+IfQ6yXrM/dXy4h13zR6IzHnJ8tBH0VvvPesz/fMrN/HWw6av13CZuS12qEU/Jij
-+8ZvpKxn6kd1BO4+g9UW4ExsEq95+qFTOJIjhlm7yJCCsHfNq/r1nIa/NbpigQG0
-TS26r8sWTLgPmYysBTONFwX+NtCbbESRwRMogQIDAQABAoIBABCU9cqkVjV253T9
-qpAjICffIfQlw3+y4lEJE51k7OJfxjgLW4Mg9ECxo98EOpS51pnbkBfU59HgWsZB
-vzxXij+eYUGHXyKryYBcDD0wOOJSlMfJeaJDjhmpd+bfNf9+Xnhyxx0zFR0olef+
-jAVjo6Bk6AR9fk3l9qsYkSh4y0AJnJuPnMjISqjn6LfGXf1VAVCkHljLRTHzIzw3
-ZbV1rNWNQq8znaNGQP1sGAXpu1x+XfQFJZVUDtVeC9E2bB3TQe5D+LIFCtZrUkpK
-PNOCqce9oOUgErUub73+fTMMvBX5rU2m6zuhmZjl9s8PHVsDv1/GMyU/6Krrhh8E
-n11ipEkCgYEAw+oFfJhs4DtC+IqC0WaI4v6BB4EoYDoaAhHjNQZ0gx5k1AtIeNpN
-YKCFF0IPyIQbDWve+hspxJ47zcOZuS85UfRFjkfohwYE4UdhViUAwsIiFePZMEz8
-3R2XGL0lHbXnZ2KRD0u9w+u9YfPLngsnHBUZxRp7iG48apP2nYfRCrcCgYEA9yHC
-NOVb7ER9NMrSRkCCh6qM0jPUsCFFBPv63s6ZKKioyqHYUPVPP9ZxxsQpya+NUPiS
-vf56ccGFqtjKMDIMQh+POTPkFEyjFHwoxXxg76xz2uCpyQVsSQTNCwy9LkEavjNe
-sebB+a8iH2gTL5zIXObaTBC4iANhQ+OtR6BDjocCgYAVT6qjIA2P4sJpON/8GVRA
-pQCyKUmUFh3oJbv6c6ZO8Qp0ynlqtAyAu1Ve70+6NyyeLCLIQBYuDixhOKrLKyjo
-ElNSo93WekAjpVkgPswzY1zD1tI0X9uNzf82sLSN49C1PVKcQFf3LPif5B49Jedu
-NZllCHlxoNQvn8LO5gxGRwKBgQCD+CYSQyy8VbKa33g8hbRuqBe9JGp+h7WovLqy
-ApdtS+ufEaBHU0g3qddmMliyWCnZxHPwO5W9a39qxYvrAr7jDKFaBajVYjtv9AF9
-vDazpl7T0kc4jsnNkF/Cd9IKgj+6tAnsbHLHV8ucA+LC+TFR0wFdv0wbbdqh+1IM
-Prv0vwKBgFUAow5ttHgBtG5Ap4evsRgWzGaF2wOGzEOK3rwS5fIGY67A1YN35Q+C
-SmkGVcozf8rFeyMCwk68XoLff1i14iQDAarAjvdWo0ww/gjA50kdrgFb7FpjbZNE
-0kOV6q4vFJIjT8g2CeJ1MmBEuHhflC+gNBWmlEs+xaghA7/cbop2
------END RSA PRIVATE KEY-----'''
-    a=RsaEncrypt(mes,pubkey)
-    b=RsaDecrypt(a,prikey)
-    c=RsaSignal(mes,prikey)
-
-
-
-
-    digitttt='IUvR9162yrRtQAfhhVZrefB9yCwSL+kf81iudLqcDyKesokwvhjZeOpUlXR7zYOokThhelPrqtE4DIsXIxNb7FY9QgwLFkCGSQG17h09FJaZQmDLaUmtDutXDFgGZ9j5Mzln1nCtOWDreey9YbeJaRsDRj4jjp1ZOCdsC8pN65M='
-    digitttt=digitttt.encode('utf-8')
-    pppuuu='''-----BEGIN PUBLIC KEY-----
-MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCsCp6xhC5Tr7ucaRNU3aKMsvv8
-PtxlQdl4LTys5F6wKM11MeJSXwruiUBbDHhySLfy5ZPpYxsfa5ez6hbaZoMyk+xd
-p1jWehUWqouFA/OmHxQ4jjmhxJ40cNcm/TAkyl8zci0uGaird26x2NUa4o8BpnE5
-TokPhvYzdhsx05FQuwIDAQAB
------END PUBLIC KEY-----'''
-    pppuuu=pppuuu.encode('utf-8')
-    mess='你好，世界'
-    d = VerRsaSignal(mess, digitttt, pppuuu)
-    print("d",d)
+    signature_bytes = base64.b64decode(_to_bytes(signature))
+    return verifier.verify(digest, signature_bytes)

--- a/algorithms/generateKey.py
+++ b/algorithms/generateKey.py
@@ -1,15 +1,28 @@
-import Crypto.PublicKey.RSA
-import Crypto.Random
-#生成密钥
-#利用库中默认的generate来生成
-def generateMyKey(dir):
-    x = Crypto.PublicKey.RSA.generate(1024)
-    privateKey = x.exportKey("PEM")  # 生成私钥
-    publicKey = x.publickey().exportKey()  # 生成公钥
-    with open(dir+"private.pem", "wb") as x:
-        x.write(privateKey)
-    with open(dir+"public.pem", "wb") as x:
-        x.write(publicKey)
-    return(privateKey,publicKey)
+"""RSA key generation utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+from Crypto.PublicKey import RSA
 
 
+def generateMyKey(prefix: str, bits: int = 2048) -> Tuple[bytes, bytes]:
+    """Generate RSA keypair and write to `<prefix>private.pem/public.pem`."""
+    if bits < 1024:
+        raise ValueError("bits must be >= 1024")
+
+    key = RSA.generate(bits)
+    private_key = key.export_key("PEM")
+    public_key = key.publickey().export_key("PEM")
+
+    private_path = Path(f"{prefix}private.pem")
+    public_path = Path(f"{prefix}public.pem")
+    private_path.parent.mkdir(parents=True, exist_ok=True)
+    public_path.parent.mkdir(parents=True, exist_ok=True)
+
+    private_path.write_bytes(private_key)
+    public_path.write_bytes(public_key)
+
+    return private_key, public_key

--- a/algorithms/hashalg.py
+++ b/algorithms/hashalg.py
@@ -1,11 +1,25 @@
-import hashlib
-#hash函数
-def hash_sha256(datas): #sha256 哈希函数
-    x=hashlib.sha256()
-    x.update(datas)
-    s=x.hexdigest()
-    return s
+"""Hash helpers."""
 
-if __name__ == '__main__':
-    e=hash_sha256('你好'.encode('utf-8'))
-    print(e)
+from __future__ import annotations
+
+import hashlib
+from typing import Union
+
+
+BytesLike = Union[bytes, bytearray]
+
+
+def hash_sha256(datas: Union[str, BytesLike]) -> str:
+    """Return SHA-256 hex digest for str/bytes input."""
+    if isinstance(datas, str):
+        payload = datas.encode("utf-8")
+    elif isinstance(datas, (bytes, bytearray)):
+        payload = bytes(datas)
+    else:
+        raise TypeError(f"Unsupported data type: {type(datas)!r}")
+
+    return hashlib.sha256(payload).hexdigest()
+
+
+if __name__ == "__main__":
+    print(hash_sha256("你好"))

--- a/test/test_crypto_algorithms.py
+++ b/test/test_crypto_algorithms.py
@@ -1,0 +1,42 @@
+import unittest
+
+from algorithms import AESalgorithm, RSAalgorithm, generateKey, hashalg
+
+
+class CryptoAlgorithmsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.private_key, cls.public_key = generateKey.generateMyKey("keys/test/test")
+
+    def test_aes_encrypt_decrypt_roundtrip_text(self):
+        key = AESalgorithm.genKey()
+        plaintext = "工业级重构验证"
+        encrypted = AESalgorithm.AesEncrypt(plaintext, key)
+        decrypted = AESalgorithm.AesDecrypt(encrypted, key)
+        self.assertEqual(decrypted.decode("utf-8"), plaintext)
+
+    def test_aes_encrypt_decrypt_roundtrip_bytes(self):
+        key = AESalgorithm.genKey()
+        payload = b"\x00\x01binary-data\xfe"
+        encrypted = AESalgorithm.AesEncrypt(payload, key)
+        decrypted = AESalgorithm.AesDecrypt(encrypted, key)
+        self.assertEqual(decrypted, payload)
+
+    def test_rsa_encrypt_decrypt_roundtrip(self):
+        data = b"one-time-key"
+        encrypted = RSAalgorithm.RsaEncrypt(data, self.public_key)
+        decrypted = RSAalgorithm.RsaDecrypt(encrypted, self.private_key)
+        self.assertEqual(decrypted, data)
+
+    def test_rsa_sign_verify(self):
+        message = "signed-message"
+        signature = RSAalgorithm.RsaSignal(message, self.private_key)
+        self.assertTrue(RSAalgorithm.VerRsaSignal(message, signature, self.public_key))
+
+    def test_hash_sha256(self):
+        digest = hashalg.hash_sha256("abc")
+        self.assertEqual(digest, "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Modernize and harden the project's cryptographic helpers to follow industrial best practices (clear input contracts, safer randomness, deterministic padding) while preserving existing public APIs for compatibility. 
- Remove debug side-effects and fragile behaviors that cause runtime/compatibility issues across Python and crypto library versions. 

### Description
- Refactored `algorithms/AESalgorithm.py` to add explicit byte handling and typing, NUL-based padding helper `add_to_16`, deterministic AES-CBC encode/decode flows, and secure random key generation via `secrets` while preserving `AesEncrypt`, `AesDecrypt`, and `genKey` APIs. 
- Refactored `algorithms/RSAalgorithm.py` to normalize string/bytes inputs, remove noisy prints, add clear error handling for invalid base64 ciphertext and decryption failures, and keep `RsaEncrypt`, `RsaDecrypt`, `RsaSignal`, `VerRsaSignal` interfaces. 
- Improved `algorithms/generateKey.py` to generate 2048-bit RSA keys by default, validate `bits` parameter, and ensure output directories are created before writing keys. 
- Hardened `algorithms/hashalg.py` with explicit input validation for `str`/`bytes` and a stable `hash_sha256` contract. 
- Added `test/test_crypto_algorithms.py` regression suite covering AES roundtrips (text and bytes), RSA encrypt/decrypt and sign/verify, and SHA-256 vector check. 

### Testing
- Ran the unit tests with `python3 -m unittest discover -s test -p 'test_*.py'`, which executed 5 tests and returned `OK`. 
- Byte-compiled the refactored modules and main scripts with `python3 -m py_compile algorithms/AESalgorithm.py algorithms/RSAalgorithm.py algorithms/generateKey.py algorithms/hashalg.py Client.py Server.py`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69885c4895e0832ea19c5213255bee7c)